### PR TITLE
Removed dependacy on stathat.py, updated to work with Python 3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-stathat==0.0.2
+requests==2.13.0

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if sys.argv[-1] == "publish":
     os.system("python setup.py sdist upload")
     sys.exit()
 
-required = ['stathat']
+required = ['requests==2.13.0']
 
 setup(
     name='stathat-async',

--- a/stathatasync.py
+++ b/stathatasync.py
@@ -20,28 +20,38 @@ Enjoy!
 
 """
 
-import stathat
-from Queue import Queue
+import requests
+from queue import Queue
 from threading import Thread
 
+STATHAT_API="http://api.stathat.com/ez"
 
-def worker(email, queue):
-    stats = stathat.StatHat(email)
+
+def worker(email, session, queue):
 
     while True:
         command, key, value = queue.get()
         if command == 'value':
-            stats.value(key, value)
+            session.post(url=STATHAT_API, data={
+                "ezkey": email,
+                "stat": key,
+                "value": value
+            })
         if command == 'count':
-            stats.count(key, value)
+            session.post(url=STATHAT_API, data={
+                "ezkey": email,
+                "stat": key,
+                "count": value
+            })
         queue.task_done()
 
 
 class StatHat(object):
 
     def __init__(self, email):
+        session = requests.session()
         self.queue = Queue()
-        thread = Thread(target=worker, args=(email, self.queue))
+        thread = Thread(target=worker, args=(email, session, self.queue))
         thread.daemon = True
         thread.start()
 


### PR DESCRIPTION
Hey there,

Ran into problems getting this to work with Python 3.5 and so I changed a few things to make it work. Thought I should PR it in case you were interested.

The dependancy Stathat.py that was being wrapped by this package has been removed as the latest version isn't available from PyPi and the version that is available has a bug that means it won't run. In any case, the functionality provided by stathat was just the ability to send two API calls to stathat and so I have reimplemented them using requests.

Plus there was a minor change to the Queue module (renamed to use a lowercase q) that I fixed up.

Not sure about compatibility with Python 2.7 but I think it would be easy enough to make it work.

Tomm :)